### PR TITLE
Added Audio Focus for playback control

### DIFF
--- a/app/src/main/java/com/naman14/timberx/playback/AudioFocusHelper.kt
+++ b/app/src/main/java/com/naman14/timberx/playback/AudioFocusHelper.kt
@@ -1,0 +1,116 @@
+package com.naman14.timberx.playback
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import com.naman14.timberx.util.Utils.isOreo
+
+/**
+ * Project - TimberX
+ * Created with Android Studio
+ * Company: Gigabyte Developers
+ * User: Emmanuel Nwokoma
+ * Title: Founder and CEO
+ * Day: Tuesday, 09
+ * Month: June
+ * Year: 2020
+ * Date: 09 Jun, 2020
+ * Time: 4:43 PM
+ * Desc: AudioFocusHelper
+ **/
+
+typealias OnAudioFocusGain = AudioFocusHelper.() -> Unit
+typealias OnAudioFocusLoss = AudioFocusHelper.() -> Unit
+typealias OnAudioFocusLossTransient = AudioFocusHelper.() -> Unit
+typealias OnAudioFocusLossTransientCanDuck = AudioFocusHelper.() -> Unit
+
+interface AudioFocusHelper {
+    var isAudioFocusGranted: Boolean
+
+    fun requestPlayback(): Boolean
+    fun abandonPlayback()
+    fun onAudioFocusGain(audioFocusGain: OnAudioFocusGain)
+    fun onAudioFocusLoss(audioFocusLoss: OnAudioFocusLoss)
+    fun onAudioFocusLossTransient(audioFocusLossTransient: OnAudioFocusLossTransient)
+    fun onAudioFocusLossTransientCanDuck(audioFocusLossTransientCanDuck: OnAudioFocusLossTransientCanDuck)
+    fun setVolume(volume: Int)
+}
+
+class AudioFocusHelperImplementation(
+        context: Context
+) : AudioFocusHelper, AudioManager.OnAudioFocusChangeListener {
+
+    private val audioManager: AudioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+
+    private var audioFocusGainCallback: OnAudioFocusGain = {}
+    private var audioFocusLossCallback: OnAudioFocusLoss = {}
+    private var audioFocusLossTransientCallback: OnAudioFocusLossTransient = {}
+    private var audioFocusLossTransientCanDuckCallback: OnAudioFocusLossTransientCanDuck = {}
+
+    override fun onAudioFocusChange(focusChange: Int) {
+        when (focusChange) {
+            AudioManager.AUDIOFOCUS_GAIN -> audioFocusGainCallback()
+            AudioManager.AUDIOFOCUS_LOSS -> audioFocusLossCallback()
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> audioFocusLossTransientCallback()
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> audioFocusLossTransientCanDuckCallback()
+        }
+    }
+
+    override var isAudioFocusGranted: Boolean = false
+
+    override fun requestPlayback(): Boolean {
+        val state = if (isOreo()) {
+            val attr = AudioAttributes.Builder().apply {
+                setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                setUsage(AudioAttributes.USAGE_MEDIA)
+            }.build()
+            audioManager.requestAudioFocus(
+                    AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                            .setAudioAttributes(attr)
+                            .setAcceptsDelayedFocusGain(true)
+                            .setOnAudioFocusChangeListener(this)
+                            .build()
+            )
+        } else audioManager.requestAudioFocus(this,
+                AudioManager.STREAM_MUSIC,
+                AudioManager.AUDIOFOCUS_GAIN
+        )
+        return state == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+    }
+
+    override fun abandonPlayback() {
+        if (isOreo()) {
+            val attr = AudioAttributes.Builder().apply {
+                setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                setUsage(AudioAttributes.USAGE_MEDIA)
+            }.build()
+            audioManager.abandonAudioFocusRequest(
+                    AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                            .setOnAudioFocusChangeListener(this)
+                            .setAudioAttributes(attr)
+                            .build()
+            )
+        } else audioManager.abandonAudioFocus(this)
+    }
+
+    override fun onAudioFocusGain(audioFocusGain: OnAudioFocusGain) {
+        audioFocusGainCallback = audioFocusGain
+    }
+
+    override fun onAudioFocusLoss(audioFocusLoss: OnAudioFocusLoss) {
+        audioFocusLossCallback = audioFocusLoss
+    }
+
+    override fun onAudioFocusLossTransient(audioFocusLossTransient: OnAudioFocusLossTransient) {
+        audioFocusLossTransientCallback = audioFocusLossTransient
+    }
+
+    override fun onAudioFocusLossTransientCanDuck(audioFocusLossTransientCanDuck: OnAudioFocusLossTransientCanDuck) {
+        audioFocusLossTransientCanDuckCallback = audioFocusLossTransientCanDuck
+    }
+
+    override fun setVolume(volume: Int) {
+        audioManager.adjustVolume(volume, AudioManager.FLAG_PLAY_SOUND)
+    }
+}

--- a/app/src/main/java/com/naman14/timberx/playback/AudioFocusHelper.kt
+++ b/app/src/main/java/com/naman14/timberx/playback/AudioFocusHelper.kt
@@ -1,9 +1,12 @@
 package com.naman14.timberx.playback
 
 import android.content.Context
+import android.content.Context.AUDIO_SERVICE
 import android.media.AudioAttributes
 import android.media.AudioFocusRequest
 import android.media.AudioManager
+import android.media.AudioManager.*
+import com.naman14.timberx.extensions.systemService
 import com.naman14.timberx.util.Utils.isOreo
 
 /**
@@ -39,9 +42,9 @@ interface AudioFocusHelper {
 
 class AudioFocusHelperImplementation(
         context: Context
-) : AudioFocusHelper, AudioManager.OnAudioFocusChangeListener {
+) : AudioFocusHelper, OnAudioFocusChangeListener {
 
-    private val audioManager: AudioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    private val audioManager: AudioManager = context.systemService(AUDIO_SERVICE)
 
     private var audioFocusGainCallback: OnAudioFocusGain = {}
     private var audioFocusLossCallback: OnAudioFocusLoss = {}
@@ -50,10 +53,10 @@ class AudioFocusHelperImplementation(
 
     override fun onAudioFocusChange(focusChange: Int) {
         when (focusChange) {
-            AudioManager.AUDIOFOCUS_GAIN -> audioFocusGainCallback()
-            AudioManager.AUDIOFOCUS_LOSS -> audioFocusLossCallback()
-            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> audioFocusLossTransientCallback()
-            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> audioFocusLossTransientCanDuckCallback()
+            AUDIOFOCUS_GAIN -> audioFocusGainCallback()
+            AUDIOFOCUS_LOSS -> audioFocusLossCallback()
+            AUDIOFOCUS_LOSS_TRANSIENT -> audioFocusLossTransientCallback()
+            AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> audioFocusLossTransientCanDuckCallback()
         }
     }
 
@@ -66,17 +69,14 @@ class AudioFocusHelperImplementation(
                 setUsage(AudioAttributes.USAGE_MEDIA)
             }.build()
             audioManager.requestAudioFocus(
-                    AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                    AudioFocusRequest.Builder(AUDIOFOCUS_GAIN)
                             .setAudioAttributes(attr)
                             .setAcceptsDelayedFocusGain(true)
                             .setOnAudioFocusChangeListener(this)
                             .build()
             )
-        } else audioManager.requestAudioFocus(this,
-                AudioManager.STREAM_MUSIC,
-                AudioManager.AUDIOFOCUS_GAIN
-        )
-        return state == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        } else audioManager.requestAudioFocus(this, STREAM_MUSIC, AUDIOFOCUS_GAIN)
+        return state == AUDIOFOCUS_REQUEST_GRANTED
     }
 
     override fun abandonPlayback() {
@@ -86,7 +86,7 @@ class AudioFocusHelperImplementation(
                 setUsage(AudioAttributes.USAGE_MEDIA)
             }.build()
             audioManager.abandonAudioFocusRequest(
-                    AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                    AudioFocusRequest.Builder(AUDIOFOCUS_GAIN)
                             .setOnAudioFocusChangeListener(this)
                             .setAudioAttributes(attr)
                             .build()
@@ -111,6 +111,6 @@ class AudioFocusHelperImplementation(
     }
 
     override fun setVolume(volume: Int) {
-        audioManager.adjustVolume(volume, AudioManager.FLAG_PLAY_SOUND)
+        audioManager.adjustVolume(volume, FLAG_PLAY_SOUND)
     }
 }

--- a/app/src/main/java/com/naman14/timberx/playback/MediaModule.kt
+++ b/app/src/main/java/com/naman14/timberx/playback/MediaModule.kt
@@ -34,6 +34,10 @@ val mediaModule = module {
     } bind Queue::class
 
     factory {
+        AudioFocusHelperImplementation(get())
+    } bind (AudioFocusHelper::class)
+
+    factory {
         RealSongPlayer(get(), get(), get(), get(), get())
     } bind SongPlayer::class
 }

--- a/app/src/main/java/com/naman14/timberx/playback/MediaModule.kt
+++ b/app/src/main/java/com/naman14/timberx/playback/MediaModule.kt
@@ -38,6 +38,6 @@ val mediaModule = module {
     } bind (AudioFocusHelper::class)
 
     factory {
-        RealSongPlayer(get(), get(), get(), get(), get())
+        RealSongPlayer(get(), get(), get(), get(), get(), get())
     } bind SongPlayer::class
 }

--- a/app/src/main/java/com/naman14/timberx/playback/players/MediaSessionCallback.kt
+++ b/app/src/main/java/com/naman14/timberx/playback/players/MediaSessionCallback.kt
@@ -17,8 +17,7 @@ package com.naman14.timberx.playback.players
 import android.media.AudioManager
 import android.os.Bundle
 import android.support.v4.media.session.MediaSessionCompat
-import android.support.v4.media.session.PlaybackStateCompat
-import android.support.v4.media.session.PlaybackStateCompat.STATE_NONE
+import android.support.v4.media.session.PlaybackStateCompat.*
 import com.naman14.timberx.constants.Constants.ACTION_PLAY_NEXT
 import com.naman14.timberx.constants.Constants.ACTION_QUEUE_REORDER
 import com.naman14.timberx.constants.Constants.ACTION_REPEAT_QUEUE
@@ -50,7 +49,7 @@ class MediaSessionCallback(
 
     init {
         audioFocusHelper.onAudioFocusGain {
-            val isPlaying = songPlayer.getSession().controller.playbackState.state == PlaybackStateCompat.STATE_PLAYING
+            val isPlaying = songPlayer.getSession().controller.playbackState.state == STATE_PLAYING
             if (isAudioFocusGranted && !isPlaying) {
                 songPlayer.playSong()
             } else audioFocusHelper.setVolume(AudioManager.ADJUST_RAISE)
@@ -63,7 +62,7 @@ class MediaSessionCallback(
         }
 
         audioFocusHelper.onAudioFocusLossTransient {
-            val isPlaying = songPlayer.getSession().controller.playbackState.state == PlaybackStateCompat.STATE_PLAYING
+            val isPlaying = songPlayer.getSession().controller.playbackState.state == STATE_PLAYING
             if (isPlaying) {
                 isAudioFocusGranted = true
                 songPlayer.pause()
@@ -123,11 +122,10 @@ class MediaSessionCallback(
         super.onSetRepeatMode(repeatMode)
         val bundle = mediaSession.controller.playbackState.extras ?: Bundle()
         songPlayer.setPlaybackState(
-                PlaybackStateCompat.Builder(mediaSession.controller.playbackState)
-                        .setExtras(bundle.apply {
-                            putInt(REPEAT_MODE, repeatMode)
-                        }
-                        ).build()
+            Builder(mediaSession.controller.playbackState)
+                    .setExtras(bundle.apply {
+                        putInt(REPEAT_MODE, repeatMode)
+                    }).build()
         )
     }
 
@@ -135,10 +133,10 @@ class MediaSessionCallback(
         super.onSetShuffleMode(shuffleMode)
         val bundle = mediaSession.controller.playbackState.extras ?: Bundle()
         songPlayer.setPlaybackState(
-                PlaybackStateCompat.Builder(mediaSession.controller.playbackState)
-                        .setExtras(bundle.apply {
-                            putInt(SHUFFLE_MODE, shuffleMode)
-                        }).build()
+            Builder(mediaSession.controller.playbackState)
+                    .setExtras(bundle.apply {
+                        putInt(SHUFFLE_MODE, shuffleMode)
+                    }).build()
         )
     }
 

--- a/app/src/main/java/com/naman14/timberx/playback/players/MediaSessionCallback.kt
+++ b/app/src/main/java/com/naman14/timberx/playback/players/MediaSessionCallback.kt
@@ -49,6 +49,7 @@ class MediaSessionCallback(
 
     init {
         audioFocusHelper.onAudioFocusGain {
+            Timber.d("GAIN")
             val isPlaying = songPlayer.getSession().controller.playbackState.state == STATE_PLAYING
             if (isAudioFocusGranted && !isPlaying) {
                 songPlayer.playSong()
@@ -56,12 +57,14 @@ class MediaSessionCallback(
             isAudioFocusGranted = false
         }
         audioFocusHelper.onAudioFocusLoss {
+            Timber.d("LOSS")
             abandonPlayback()
             isAudioFocusGranted = false
             songPlayer.pause()
         }
 
         audioFocusHelper.onAudioFocusLossTransient {
+            Timber.d("TRANSIENT")
             val isPlaying = songPlayer.getSession().controller.playbackState.state == STATE_PLAYING
             if (isPlaying) {
                 isAudioFocusGranted = true
@@ -76,15 +79,18 @@ class MediaSessionCallback(
     }
 
     override fun onPause() {
+        Timber.d("onPause()")
         songPlayer.pause()
     }
 
     override fun onPlay() {
+        Timber.d("onPlay()")
         if (audioFocusHelper.requestPlayback())
             songPlayer.playSong()
     }
 
     override fun onPlayFromSearch(query: String?, extras: Bundle?) {
+        Timber.d("onPlayFromSearch()")
         query?.let {
             val song = songsRepository.searchSongs(query, 1)
             if (song.isNotEmpty()) {
@@ -94,6 +100,7 @@ class MediaSessionCallback(
     }
 
     override fun onPlayFromMediaId(mediaId: String, extras: Bundle?) {
+        Timber.d("onPlayFromMediaId()")
         val songId = MediaID().fromString(mediaId).mediaId!!.toLong()
         songPlayer.playSong(songId)
 
@@ -110,13 +117,25 @@ class MediaSessionCallback(
         }
     }
 
-    override fun onSeekTo(pos: Long) = songPlayer.seekTo(pos.toInt())
+    override fun onSeekTo(pos: Long) {
+        Timber.d("onSeekTo()")
+        songPlayer.seekTo(pos.toInt())
+    }
 
-    override fun onSkipToNext() = songPlayer.nextSong()
+    override fun onSkipToNext() {
+        Timber.d("onSkipToNext()")
+        songPlayer.nextSong()
+    }
 
-    override fun onSkipToPrevious() = songPlayer.previousSong()
+    override fun onSkipToPrevious() {
+        Timber.d("onSkipToPrevious()")
+        songPlayer.previousSong()
+    }
 
-    override fun onStop() = songPlayer.stop()
+    override fun onStop() {
+        Timber.d("onStop()")
+        songPlayer.stop()
+    }
 
     override fun onSetRepeatMode(repeatMode: Int) {
         super.onSetRepeatMode(repeatMode)

--- a/app/src/main/java/com/naman14/timberx/playback/players/MediaSessionCallback.kt
+++ b/app/src/main/java/com/naman14/timberx/playback/players/MediaSessionCallback.kt
@@ -35,11 +35,13 @@ import com.naman14.timberx.constants.Constants.SONG
 import com.naman14.timberx.constants.Constants.SONGS_LIST
 import com.naman14.timberx.db.QueueDao
 import com.naman14.timberx.models.MediaID
+import com.naman14.timberx.playback.AudioFocusHelper
 import com.naman14.timberx.repository.SongsRepository
 
 class MediaSessionCallback(
     private val mediaSession: MediaSessionCompat,
     private val songPlayer: SongPlayer,
+    private val audioFocusHelper: AudioFocusHelper,
     private val songsRepository: SongsRepository,
     private val queueDao: QueueDao
 ) : MediaSessionCompat.Callback() {

--- a/app/src/main/java/com/naman14/timberx/playback/players/SongPlayer.kt
+++ b/app/src/main/java/com/naman14/timberx/playback/players/SongPlayer.kt
@@ -57,6 +57,7 @@ import com.naman14.timberx.extensions.isPlaying
 import com.naman14.timberx.extensions.position
 import com.naman14.timberx.extensions.toSongIDs
 import com.naman14.timberx.models.Song
+import com.naman14.timberx.playback.AudioFocusHelper
 import com.naman14.timberx.repository.SongsRepository
 import com.naman14.timberx.util.MusicUtils
 import timber.log.Timber
@@ -126,7 +127,8 @@ class RealSongPlayer(
     private val musicPlayer: MusicPlayer,
     private val songsRepository: SongsRepository,
     private val queueDao: QueueDao,
-    private val queue: Queue
+    private val queue: Queue,
+    audioFocusHelper: AudioFocusHelper
 ) : SongPlayer {
 
     private var isInitialized: Boolean = false
@@ -141,7 +143,15 @@ class RealSongPlayer(
 
     private var mediaSession = MediaSessionCompat(context, context.getString(R.string.app_name)).apply {
         setFlags(MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS or MediaSessionCompat.FLAG_HANDLES_TRANSPORT_CONTROLS)
-        setCallback(MediaSessionCallback(this, this@RealSongPlayer, songsRepository, queueDao))
+        setCallback(
+            MediaSessionCallback(
+                this,
+                this@RealSongPlayer,
+                audioFocusHelper,
+                songsRepository,
+                queueDao
+            )
+        )
         setPlaybackState(stateBuilder.build())
 
         val sessionIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)


### PR DESCRIPTION
Fixes https://github.com/naman14/TimberX/issues/57 

- Stop playback when another app takes up the Audio Focus
- Pause and resume when Audio Focus is transient (temporarily lost) **example**: when answering a call